### PR TITLE
Add property ref to HackneyAPI::Arrears

### DIFF
--- a/lib/hackney_api/arrears/test.rb
+++ b/lib/hackney_api/arrears/test.rb
@@ -21,7 +21,7 @@ module HackneyAPI
           dto: {
             DirectUser: direct_user,
             SourceSystem: source_system,
-            AgreementSearch: { MaxRecords: 10 }
+            AgreementSearch: search_criteria
           }
         })
       end
@@ -41,6 +41,13 @@ module HackneyAPI
 
       def source_system
         ENV['UH_WS_SOURCE_SYSTEM']
+      end
+
+      def search_criteria
+        {
+          PropertyRef: ENV['UH_WS_EXAMPLE_PROPERTY_REF'],
+          MaxRecords: 10
+        }
       end
 
       def client


### PR DESCRIPTION
We add the property ref so we finally have a valid web service call against UH.

We inject the property ref via ENV so we keep UH references out of GitHub and also can inject different ones whilst we test.